### PR TITLE
Providing fix for Lazy Loading

### DIFF
--- a/src/Geta.Optimizely.GenericLinks/PropertyLinkDataCollection.cs
+++ b/src/Geta.Optimizely.GenericLinks/PropertyLinkDataCollection.cs
@@ -285,7 +285,7 @@ public abstract class PropertyLinkDataCollection<TLinkData> : PropertyLinkDataCo
     protected override void SetDefaultValue()
     {
         base.SetDefaultValue();
-        _linkItemCollection = [];
+        _linkItemCollection = null;
     }
 
     protected virtual LinkDataCollection<TLinkData>? ParseToLinkCollection(string? value)


### PR DESCRIPTION
The Generic Links package began running into issues in v1.9.2 where on startup, LinkDataCollection would not populate with data from the DB until a save had taken place. Looking into the issue this appears to be due to the _linkItemCollection inPropertyLinkDataCollection<TLinkData> being defaulted to an empty array rather than null. When reverting this in theSetDefaultValue method to null, the ILazyProperty functionality works as expected and we see the LinkDataCollection objects populating as expected at startup.